### PR TITLE
Accounting for colons in game titles

### DIFF
--- a/src/main/java/lacourd/lendinglibrary/models/BGGApiService.java
+++ b/src/main/java/lacourd/lendinglibrary/models/BGGApiService.java
@@ -52,6 +52,7 @@ public class BGGApiService {
 
     public String searchGameAndGetCoverImage(String gameTitle) {
         // Step 1: Search for the game and retrieve the game ID with exact match
+        System.out.println(gameTitle);
         String searchUrlWithExact = "https://boardgamegeek.com/xmlapi2/search?type=boardgame&query=" + gameTitle + "&exact=1";
         ResponseEntity<String> searchResponseExact = restTemplate.getForEntity(searchUrlWithExact, String.class);
 //        System.out.println(searchResponseExact);
@@ -109,7 +110,9 @@ public class BGGApiService {
             logUnmarshalledResult(result);
 
             List<BGGItem> items = result.getItems();
-            System.out.println(items.toString());
+            if (items != null) {
+                System.out.println(items.toString());
+            }
 
             if (items != null && !items.isEmpty()) {
                 gameId = items.get(0).getId();

--- a/src/main/java/lacourd/lendinglibrary/models/Game.java
+++ b/src/main/java/lacourd/lendinglibrary/models/Game.java
@@ -104,14 +104,10 @@ public class Game extends AbstractEntity{
     }
 
     private String preprocessNameForSearch(String name) {
-        try {
-            this.searchableName = URLEncoder.encode(this.name, StandardCharsets.UTF_8.toString());
-            return searchableName;
-        } catch (UnsupportedEncodingException e) {
-            // Handle encoding exception, if needed
-            e.printStackTrace();
-            return null;
-        }
+        this.searchableName = name.replace(" ", "+");
+        this.searchableName = this.searchableName.replace("&", "and");
+
+        return searchableName;
     }
 
     @Override


### PR DESCRIPTION
Changes getSearchableName() method to replace spaces with plus signs and ampersands with "and," but otherwise avoid the unicode conversion of characters. Will need to see if I encounter any other problems with game names.