### PR TITLE
Adds styling to display cover images consistently on the details page

### DIFF
--- a/src/main/resources/static/styles.css
+++ b/src/main/resources/static/styles.css
@@ -4,3 +4,13 @@ body {
 .error {
     color: red;
 }
+.image-container {
+      position: relative;
+      height: 500px; /* Fixed height for all images */
+   }
+
+.image-container img {
+      position: absolute;
+      max-width: 100%; /* Limits width to the container's width, preserving aspect ratio */
+      height: 100%;
+   }

--- a/src/main/resources/templates/games/detail.html
+++ b/src/main/resources/templates/games/detail.html
@@ -5,7 +5,9 @@
 
 <header th:replace="fragments :: header"></header>
 
-<image th:src="${game.gameDetails.coverImage}"/>
+<div class="image-container">
+    <image th:src="${game.gameDetails.coverImage}" th:alt="'Cover image for ' + ${game.name}"/>
+</div>
 <table class="table table-striped">
     <tr>
         <th>Description</th>


### PR DESCRIPTION
Covers are a max height of 500px; width scales based on the size of the image.

Closes #18 